### PR TITLE
PlayerPrefs editor controls

### DIFF
--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ebb9c7ba40acff94b915b3e67a0ba5a5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/PlayerPrefsManager.cs
+++ b/Assets/Editor/PlayerPrefsManager.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using UnityEditor;
+
+public class PlayerPrefsManager : MonoBehaviour {
+
+    [MenuItem("PlayerPrefs Manager/Delete All PlayerPrefs", priority = 1)]
+    static void DeleteAll(){
+        PlayerPrefs.DeleteAll();
+        Debug.Log("All PlayerPrefs have been deleted.");
+    }
+
+    [MenuItem("PlayerPrefs Manager/Delete 'hasPlayed' key")]
+    static void DeleteHasPlayed(){
+        if(PlayerPrefs.HasKey("hasPlayed")){
+            PlayerPrefs.DeleteKey("hasPlayed");
+            Debug.Log("Deleted the 'hasPlayed' key.");
+        }else{
+            Debug.Log("No key 'hasPlayed' found.");
+        }
+    }
+
+}

--- a/Assets/Editor/PlayerPrefsManager.cs.meta
+++ b/Assets/Editor/PlayerPrefsManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ee4c09261eb2840438a7e2f3663fa65e


### PR DESCRIPTION
Added custom Menu context item (in top bar) to control aspects of what we save to locally to PlayerPrefs. 

This will become important until a proper save system is built to control things like: 
*Has the player played before? 
*What items do we need to save?
*Saving minigame progress/unlockables.

**PlayerPrefs should only be temporary and not used for important things in the final build. For the prototype is fine.