### PR TITLE
Small code fixes

### DIFF
--- a/Assets/Art/Texture/MiniMap.renderTexture
+++ b/Assets/Art/Texture/MiniMap.renderTexture
@@ -12,8 +12,8 @@ RenderTexture:
     Hash: 00000000000000000000000000000000
   m_IsAlphaChannelOptional: 0
   serializedVersion: 6
-  m_Width: 120
-  m_Height: 120
+  m_Width: 256
+  m_Height: 256
   m_AntiAliasing: 1
   m_MipCount: -1
   m_DepthStencilFormat: 94

--- a/Assets/Code/AvatarManager.cs
+++ b/Assets/Code/AvatarManager.cs
@@ -4,7 +4,7 @@ using UnityEditor;
 
 public class AvatarManager : MonoBehaviour {
     public string sceneName;
-    public SceneAsset nextSceneToLoad;
+    public string nextSceneToLoad;
     public Transform headLocation;
     private List<GameObject> headParts = new List<GameObject>();
     private int headCount = 0;
@@ -188,8 +188,10 @@ public class AvatarManager : MonoBehaviour {
         SetActiveCompanionSprite();
     }
 
-    public void FinishCustomisationBTN(){
-        GameManager.GameManagerInstance.LoadNewSceneUnloadOldScene(nextSceneToLoad,sceneName);
+    public void FinishCustomisationBTN()
+    {
+        GameManager.Instance.LoadNewScene(nextSceneToLoad);
+        GameManager.Instance.UnloadScene(sceneName);
     }
     #endregion
 }

--- a/Assets/Code/GameManager.cs
+++ b/Assets/Code/GameManager.cs
@@ -1,17 +1,16 @@
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 public class GameManager : MonoBehaviour {
-    public static GameManager GameManagerInstance {get; private set;}
-    public SceneAsset storyChapter1;
-    public SceneAsset worldHub;
+    public static GameManager Instance {get; private set;}
+    public string storyChapter1;
+    public string worldHub;
 
     void Awake(){
-        if(GameManagerInstance != null && GameManagerInstance != this){
+        if(Instance != null && Instance != this){
             Destroy(this);
         }else{
-            GameManagerInstance = this;
+            Instance = this;
         }
 
         if(SceneManager.sceneCount == 1){
@@ -26,20 +25,23 @@ public class GameManager : MonoBehaviour {
 
         if(PlayerPrefs.HasKey("hasPlayed")){
             Debug.Log("Player has completed 'tutorial', loading world hub scene.");
-            SceneManager.LoadSceneAsync(worldHub.name, LoadSceneMode.Additive);
+            SceneManager.LoadSceneAsync(worldHub, LoadSceneMode.Additive);
         }else{
             Debug.Log("First time playing. Starting Tutorial");
-            SceneManager.LoadSceneAsync(storyChapter1.name, LoadSceneMode.Additive);
+            SceneManager.LoadSceneAsync(storyChapter1, LoadSceneMode.Additive);
         }
     }
 
-    public void LoadNewSceneUnloadOldScene(SceneAsset sceneToLoad, string sceneToUnload){
-        SceneManager.UnloadSceneAsync(sceneToUnload);
-        SceneManager.LoadSceneAsync(sceneToLoad.name, LoadSceneMode.Additive);
+    public void LoadNewScene(string sceneToLoad){
+        SceneManager.LoadSceneAsync(sceneToLoad, LoadSceneMode.Additive);
     }
 
-    public void LoadMiniGame(SceneAsset minigameToLoad){
-        SceneManager.LoadSceneAsync(minigameToLoad.name, LoadSceneMode.Additive);
+    public void UnloadScene(string sceneToUnload){
+        SceneManager.UnloadSceneAsync(sceneToUnload);
+    }
+
+    public void LoadMiniGame(string minigameToLoad){
+        SceneManager.LoadSceneAsync(minigameToLoad, LoadSceneMode.Additive);
     }
 
     public void UnloadMiniGame(){

--- a/Assets/Code/MainMenu.cs
+++ b/Assets/Code/MainMenu.cs
@@ -4,11 +4,11 @@ public class MainMenu : MonoBehaviour {
     public AudioClip mainMenuMusic;
     void Start(){
         AudioManager.audioManagerInstance.PlayMusic(mainMenuMusic);
-        GameManager.GameManagerInstance.SetActiveScene(name);
+        GameManager.Instance.SetActiveScene(name);
     }
     
     public void ClickPlay(){
-        GameManager.GameManagerInstance.MainMenuPlayButon();
+        GameManager.Instance.MainMenuPlayButon();
     }
     
 }

--- a/Assets/Code/MiniGameTest.cs
+++ b/Assets/Code/MiniGameTest.cs
@@ -4,7 +4,7 @@ public class MiniGameTest : MonoBehaviour {
     public Animator anim;
     
     void Start(){
-        GameManager.GameManagerInstance.SetActiveScene(this.name);
+        GameManager.Instance.SetActiveScene(this.name);
     }
     
     public void FinishMiniGame(){

--- a/Assets/Code/SignPost.cs
+++ b/Assets/Code/SignPost.cs
@@ -4,7 +4,9 @@ using UnityEngine;
 public class SignPost : MonoBehaviour{
     public string sceneName;
 
-    public void TravelTo(SceneAsset scene){
-        GameManager.GameManagerInstance.LoadNewSceneUnloadOldScene(scene, "WorldHub");
+    public void TravelTo(string sceneToLoad)
+    {
+        GameManager.Instance.LoadNewScene(sceneToLoad);
+        GameManager.Instance.UnloadScene("WorldHub");
     }
 }

--- a/Assets/Code/StoryChapter.cs
+++ b/Assets/Code/StoryChapter.cs
@@ -19,15 +19,15 @@ public class StoryChapter : MonoBehaviour {
     public bool minigameRunning = false;
     public bool autoPlayDialogue = true;
     public bool waitForPlayerInput = false;
-    public SceneAsset sceneToLoadOnCompletion;
-    public SceneAsset minigameToRun;
+    public string sceneToLoadOnCompletion;
+    public string minigameToRun;
     
 
 
     void Start(){
         PlayerPrefs.SetInt("hasPlayed", 1);
 
-        GameManager.GameManagerInstance.SetActiveScene(name);
+        GameManager.Instance.SetActiveScene(name);
 
         StartCoroutine(GameLoop());
     }
@@ -35,7 +35,8 @@ public class StoryChapter : MonoBehaviour {
     IEnumerator GameLoop(){
         yield return DialogueFeeder();
 
-        GameManager.GameManagerInstance.LoadNewSceneUnloadOldScene(sceneToLoadOnCompletion, name);
+        GameManager.Instance.LoadNewScene(sceneToLoadOnCompletion);
+        GameManager.Instance.UnloadScene(this.name);
     }
 
     IEnumerator DialogueFeeder(){
@@ -80,13 +81,13 @@ public class StoryChapter : MonoBehaviour {
                     Debug.Log("Playing minigame");
                     dialogueCanvas.SetActive(false);
                     minigameRunning = true;
-                    GameManager.GameManagerInstance.LoadMiniGame(minigameToRun);
+                    GameManager.Instance.LoadMiniGame(minigameToRun);
                     ClearDialogue();
                     ClearBackground();
                     yield return new WaitUntil(() => !minigameRunning);
 
                     dialogueCanvas.SetActive(true);
-                    GameManager.GameManagerInstance.UnloadMiniGame();
+                    GameManager.Instance.UnloadMiniGame();
                     yield return new WaitForSeconds(1.0f);
                 }
 

--- a/Assets/Level/Prefabs/-- Managers --.prefab
+++ b/Assets/Level/Prefabs/-- Managers --.prefab
@@ -44,8 +44,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 78107d47199d48f4992e4409c30d3be9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  storyChapter1: {fileID: 102900000, guid: dcab4edb31a2e6343bd1a70854731bd4, type: 3}
-  worldHub: {fileID: 102900000, guid: 71f0d12dd816f8643b765cf8ef7ed2ea, type: 3}
+  storyChapter1: StoryChapter1
+  worldHub: WorldHub
 --- !u!1 &6294454853951191525
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Level/Scenes/AvatarCustomisation.unity
+++ b/Assets/Level/Scenes/AvatarCustomisation.unity
@@ -2888,7 +2888,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sceneName: AvatarCustomisation
-  nextSceneToLoad: {fileID: 102900000, guid: 71f0d12dd816f8643b765cf8ef7ed2ea, type: 3}
+  nextSceneToLoad: WorldHub
   headLocation: {fileID: 465282904}
   bodyLocation: {fileID: 1741385460}
   feetLocation: {fileID: 157771396}

--- a/Assets/Level/Scenes/StoryChapter1.unity
+++ b/Assets/Level/Scenes/StoryChapter1.unity
@@ -1158,8 +1158,8 @@ MonoBehaviour:
   minigameRunning: 0
   autoPlayDialogue: 1
   waitForPlayerInput: 0
-  sceneToLoadOnCompletion: {fileID: 102900000, guid: be038f9cc1fde8b49a0201ddf85b64a6, type: 3}
-  minigameToRun: {fileID: 102900000, guid: 9e990e76f813d8a40b8b8a3361e0f7d1, type: 3}
+  sceneToLoadOnCompletion: AvatarCustomisation
+  minigameToRun: MiniGameTest
 --- !u!1 &1510102097
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Level/Scenes/WorldHub.unity
+++ b/Assets/Level/Scenes/WorldHub.unity
@@ -329,10 +329,10 @@ MonoBehaviour:
       - m_Target: {fileID: 371653234}
         m_TargetAssemblyTypeName: SignPost, Assembly-CSharp
         m_MethodName: TravelTo
-        m_Mode: 2
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEditor.SceneAsset, UnityEditor.CoreModule
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 
@@ -945,6 +945,7 @@ GameObject:
   - component: {fileID: 256554414}
   - component: {fileID: 256554416}
   - component: {fileID: 256554415}
+  - component: {fileID: 256554417}
   m_Layer: 5
   m_Name: Border
   m_TagString: Untagged
@@ -969,8 +970,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 76.6, y: -71.3}
-  m_SizeDelta: {x: 120, y: 120}
+  m_AnchoredPosition: {x: 160, y: -160}
+  m_SizeDelta: {x: 310, y: 310}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &256554415
 MonoBehaviour:
@@ -1010,6 +1011,19 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 256554413}
   m_CullTransparentMesh: 1
+--- !u!114 &256554417
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 256554413}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 1
 --- !u!1 &257895569 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5542111180780342642, guid: 212907312655a4443a025a304442c17c, type: 3}
@@ -1027,7 +1041,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 257895569}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 948f4100a11a5c24981795d21301da5c, type: 3}
   m_Name: 
@@ -1177,13 +1191,13 @@ MonoBehaviour:
       - m_Target: {fileID: 371653234}
         m_TargetAssemblyTypeName: SignPost, Assembly-CSharp
         m_MethodName: TravelTo
-        m_Mode: 2
+        m_Mode: 5
         m_Arguments:
-          m_ObjectArgument: {fileID: 102900000, guid: be038f9cc1fde8b49a0201ddf85b64a6, type: 3}
-          m_ObjectArgumentAssemblyTypeName: UnityEditor.SceneAsset, UnityEditor.CoreModule
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: AvatarCustomisation
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!114 &292066821
@@ -1311,10 +1325,10 @@ MonoBehaviour:
       - m_Target: {fileID: 371653234}
         m_TargetAssemblyTypeName: SignPost, Assembly-CSharp
         m_MethodName: TravelTo
-        m_Mode: 2
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEditor.SceneAsset, UnityEditor.CoreModule
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 
@@ -2442,7 +2456,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &755930568
 Transform:
   m_ObjectHideFlags: 0
@@ -3140,7 +3154,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0.000027775764, y: 12.659994}
+  m_AnchoredPosition: {x: 0, y: 15}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &940910309
@@ -3238,7 +3252,7 @@ Camera:
   m_GameObject: {fileID: 1048757182}
   m_Enabled: 1
   serializedVersion: 2
-  m_ClearFlags: 1
+  m_ClearFlags: 4
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
@@ -3260,7 +3274,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.17
+  near clip plane: 0.1
   far clip plane: 1000
   field of view: 26.991467
   orthographic: 1
@@ -3277,7 +3291,7 @@ Camera:
   m_AllowMSAA: 1
   m_AllowDynamicResolution: 0
   m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
+  m_OcclusionCulling: 0
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
 --- !u!4 &1048757184
@@ -3289,7 +3303,7 @@ Transform:
   m_GameObject: {fileID: 1048757182}
   serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.9500122, y: 70, z: -0.8100047}
+  m_LocalPosition: {x: 0, y: 70, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3302,7 +3316,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1048757182}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 14fcba8e870f3b54997a69f59bc55231, type: 3}
   m_Name: 
@@ -3591,15 +3605,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3203261902030644824, guid: 212907312655a4443a025a304442c17c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.41601562
+      value: 0.13861084
       objectReference: {fileID: 0}
     - target: {fileID: 3203261902030644824, guid: 212907312655a4443a025a304442c17c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.4499512
+      value: 2.4499989
       objectReference: {fileID: 0}
     - target: {fileID: 3203261902030644824, guid: 212907312655a4443a025a304442c17c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -3.0700073
+      value: -7.5
       objectReference: {fileID: 0}
     - target: {fileID: 3203261902030644824, guid: 212907312655a4443a025a304442c17c, type: 3}
       propertyPath: m_LocalRotation.w
@@ -3661,6 +3675,10 @@ PrefabInstance:
       propertyPath: moveSpeed
       value: 10
       objectReference: {fileID: 0}
+    - target: {fileID: 4959801643378170157, guid: 212907312655a4443a025a304442c17c, type: 3}
+      propertyPath: m_Constraints
+      value: 80
+      objectReference: {fileID: 0}
     - target: {fileID: 5118565555141440031, guid: 212907312655a4443a025a304442c17c, type: 3}
       propertyPath: m_Enabled
       value: 0
@@ -3685,17 +3703,21 @@ PrefabInstance:
       propertyPath: m_CullingMask.m_Bits
       value: 119
       objectReference: {fileID: 0}
+    - target: {fileID: 5542111180780342641, guid: 212907312655a4443a025a304442c17c, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5542111180780342647, guid: 212907312655a4443a025a304442c17c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.41601562
+      value: 0.13861084
       objectReference: {fileID: 0}
     - target: {fileID: 5542111180780342647, guid: 212907312655a4443a025a304442c17c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.4499512
+      value: 2.4499989
       objectReference: {fileID: 0}
     - target: {fileID: 5542111180780342647, guid: 212907312655a4443a025a304442c17c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -3.0700073
+      value: -7.5
       objectReference: {fileID: 0}
     - target: {fileID: 5542111180780342647, guid: 212907312655a4443a025a304442c17c, type: 3}
       propertyPath: m_LocalRotation.w
@@ -3730,12 +3752,16 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8769038803525259336, guid: 212907312655a4443a025a304442c17c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8769038803525259336, guid: 212907312655a4443a025a304442c17c, type: 3}
       propertyPath: m_LocalPosition.y
       value: -1.78
       objectReference: {fileID: 0}
     - target: {fileID: 8769038803525259336, guid: 212907312655a4443a025a304442c17c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 4.43
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 3203261901554096024, guid: 212907312655a4443a025a304442c17c, type: 3}
@@ -3745,6 +3771,7 @@ PrefabInstance:
     - {fileID: 7888303496483045073, guid: 212907312655a4443a025a304442c17c, type: 3}
     - {fileID: 3128949090649374765, guid: 212907312655a4443a025a304442c17c, type: 3}
     - {fileID: 6341998657737914581, guid: 212907312655a4443a025a304442c17c, type: 3}
+    - {fileID: -4121083210525554576, guid: 212907312655a4443a025a304442c17c, type: 3}
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 8769038803525259336, guid: 212907312655a4443a025a304442c17c, type: 3}
       insertIndex: 0
@@ -4107,6 +4134,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 11489712, guid: 6488b6e6bbe8a9c4585b531a71d8211c, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1144622364408550, guid: 6488b6e6bbe8a9c4585b531a71d8211c, type: 3}
       propertyPath: m_Layer
       value: 4
@@ -4400,10 +4431,10 @@ MonoBehaviour:
       - m_Target: {fileID: 371653234}
         m_TargetAssemblyTypeName: SignPost, Assembly-CSharp
         m_MethodName: TravelTo
-        m_Mode: 2
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEditor.SceneAsset, UnityEditor.CoreModule
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 
@@ -4769,6 +4800,7 @@ GameObject:
   - component: {fileID: 1994392940}
   - component: {fileID: 1994392942}
   - component: {fileID: 1994392943}
+  - component: {fileID: 1994392944}
   m_Layer: 5
   m_Name: MiniMap
   m_TagString: Untagged
@@ -4793,7 +4825,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 110, y: 110}
+  m_SizeDelta: {x: 300, y: 300}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1994392942
 CanvasRenderer:
@@ -4828,8 +4860,21 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1
-    height: 1
+    width: 2
+    height: 2
+--- !u!114 &1994392944
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1994392939}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 1
 --- !u!1 &2024081414
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Scenes now need to be referenced as their scene names (string) not direct scene asset. 
Multiple small fixes in WorldHub:
* Post processing is turned off
* Limit camera script turned off (unsure what the thinking was with this, we can manage shadows far easier without messing with prerender culling.)
* Water reflections are turned off. Was throwing errors and also a luxury we can't afford on mobile.
* Minimap is now nominally larger. I suggest we mask the border to make it circular.
* Rigidbody on the character model is now frozen to rotation on the X and Z axis. This should stop the model falling over.